### PR TITLE
Add HSL, RGB support. Also, fix reversed colors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -247,10 +247,7 @@ export function fromCSS(str: string) {
         str = str.slice(0, -1);
     }
     const values = str?.match(/([a-zA-Z0-9_-]+)\((.*)\).*/);
-    if (!values) {
-        console.error("Invalid CSS gradient string: " + str);
-        return {};
-    }
+    if (!values) throw new Error("Invalid CSS Gradient function: " + str);
 
     const [, method, argString] = values;
     const args: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,8 @@ const parseColorStops = (args: Array<string>, firstColorStopIndex: number) => {
         colors.push(color);
         locations.push(parsePosition(stop));
     });
+    
+    colors.reverse();
 
     return { colors, locations };
 };


### PR DESCRIPTION
Here's a snack for using the updates. Test test cases all pass here with the web spec. Previously, colors were inverted. Also, they didn't support comma-separated colors: https://snack.expo.dev/@beatgig/css-gradient-to-expo-linear-gradient

Adds parsing for parentheses and commas to make RGB(A), HSL, etc. work.

<img width="1679" alt="Screenshot 2023-04-05 at 12 40 13 PM" src="https://user-images.githubusercontent.com/13172299/230147274-7f9695bb-55ab-4417-88f6-7eedea31a820.png">

