### PR TITLE
Fix HSL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const ANGLE = /([+-]?\d*\.?\d+)(deg|grad|rad|turn)/i;
 const SIDE_OR_CORNER =
     /^(to )?(left|top|right|bottom)( (left|top|right|bottom))?$/i;
 const PERCENTAGE_ANGLES = /^([+-]?\d*\.?\d+)% ([+-]?\d*\.?\d+)%$/i;
-const ENDS_WITH_LENGTH = /(px)|%|( 0)$/i;
+const ENDS_WITH_LENGTH = /(px)$|(%$)|( 0$)/;
 const FROM_TO_COLORSTOP =
     /^(from|to|color-stop)\((?:([\d.]+)(%)?,\s*)?(.+?)\)$/i;
 
@@ -80,7 +80,9 @@ const parseColorStops = (args: Array<string>, firstColorStopIndex: number) => {
                 ? "0%"
                 : i === args.length - 1
                     ? "100%"
-                    : null;
+                    :  // fallback to evenly spaced color stops
+                       // prettier-ignore
+                       `${((i - firstColorStopIndex) / (args.length - firstColorStopIndex - 1)) * 100}%`;
         colorStops.push({ color, stop });
     }
 


### PR DESCRIPTION
Close #7. The `stop` variable is still slightly different from the web spec. It seems that the `angle` → `direction` → `angle` code doesn't result in the perfect matching. But it's really close, so it's fine. If we can pair program this in the future, could probably figure it out in 15 minutes. But it's good enough for now.


<img width="329" alt="Screenshot 2023-04-09 at 3 35 38 PM" src="https://user-images.githubusercontent.com/13172299/230793006-7b04f642-7170-4205-ad23-50464e95ef32.png">
